### PR TITLE
fix: sanitize sbom_name which is used for filenames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2974,8 +2974,8 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -3573,7 +3573,7 @@ dependencies = [
  "globset",
  "log",
  "memchr",
- "regex-automata 0.4.6",
+ "regex-automata 0.4.9",
  "same-file",
  "walkdir",
  "winapi-util",
@@ -3787,7 +3787,7 @@ dependencies = [
  "lalrpop-util",
  "petgraph",
  "regex",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.5",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -3801,7 +3801,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
 dependencies = [
- "regex-automata 0.4.6",
+ "regex-automata 0.4.9",
 ]
 
 [[package]]
@@ -5369,14 +5369,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -5401,13 +5401,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -5430,9 +5430,9 @@ checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "relative-path"
@@ -5992,6 +5992,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sanitize-filename"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc984f4f9ceb736a7bb755c3e3bd17dc56370af2600c9780dcc48c66453da34d"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "sasl2-sys"
 version = "0.1.20+2.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6181,7 +6190,7 @@ dependencies = [
  "openssl",
  "openssl-sys",
  "regex",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.5",
  "sha1collisiondetection",
  "thiserror",
  "xxhash-rust",
@@ -6628,6 +6637,7 @@ dependencies = [
  "log",
  "packageurl 0.4.0",
  "reqwest 0.11.27",
+ "sanitize-filename",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/spog/api/Cargo.toml
+++ b/spog/api/Cargo.toml
@@ -62,5 +62,7 @@ csv = "1.3.0"
 flate2 = "1.0.35"
 tar = "0.4.43"
 
+sanitize-filename = "=0.6.0"
+
 [build-dependencies]
 trustification-version = { path = "../../version", features = ["build"] }

--- a/spog/api/src/endpoints/license.rs
+++ b/spog/api/src/endpoints/license.rs
@@ -1,6 +1,7 @@
 use crate::app_state::AppState;
 use crate::error::Error;
 use crate::license::{license_exporter, license_scanner};
+use crate::utils::get_sanitize_filename;
 use actix_web::web::{Data, PayloadConfig, ServiceConfig};
 use actix_web::{web, HttpResponse};
 use actix_web_httpauth::extractors::bearer::BearerAuth;
@@ -9,6 +10,7 @@ use bytes::BytesMut;
 use futures::TryStreamExt;
 use tracing::{info_span, instrument, Instrument};
 use trustification_auth::client::TokenProvider;
+
 extern crate sanitize_filename;
 
 pub(crate) fn configure(payload_limit: usize) -> impl FnOnce(&mut ServiceConfig) {
@@ -46,19 +48,14 @@ pub async fn download_licenses(
     let exporter = license_exporter::LicenseExporter::new(sbom_licenses);
     let zip = exporter.generate()?;
 
-    // Sanitize sbom_name
-    let options = sanitize_filename::Options {
-        truncate: true,
-        windows: true,
-        replacement: "",
-    };
-    let sbom_name = sanitize_filename::sanitize_with_options(sbom_name, options);
-
     Ok(HttpResponse::Ok()
         .content_type("application/gzip")
         .append_header((
             "Content-Disposition",
-            format!("attachment; filename=\"{}_licenses.tar.gz\"", sbom_name),
+            format!(
+                "attachment; filename=\"{}_licenses.tar.gz\"",
+                get_sanitize_filename(sbom_name)
+            ),
         ))
         .body(zip))
 }

--- a/spog/api/src/license/license_exporter.rs
+++ b/spog/api/src/license/license_exporter.rs
@@ -1,4 +1,5 @@
 use crate::license::SbomLicense;
+use crate::utils::get_sanitize_filename;
 use actix_web::body::BoxBody;
 use actix_web::http::header::ContentType;
 use actix_web::{HttpResponse, ResponseError};
@@ -9,6 +10,7 @@ use http::StatusCode;
 use std::collections::HashSet;
 use tar::Builder;
 use trustification_common::error::ErrorInformation;
+
 extern crate sanitize_filename;
 
 pub struct LicenseExporter {
@@ -135,19 +137,26 @@ impl LicenseExporter {
 
             let mut archive = Builder::new(encoder);
 
-            // Sanitize filename
-            let options = sanitize_filename::Options {
-                truncate: true,
-                windows: true,
-                replacement: "",
-            };
-            let sbom_name = sanitize_filename::sanitize_with_options(&self.sbom_license.sbom_name, options);
+            // // Sanitize filename
+            // let options = sanitize_filename::Options {
+            //     truncate: true,
+            //     windows: true,
+            //     replacement: "",
+            // };
+            // let sbom_name = sanitize_filename::sanitize_with_options(&self.sbom_license.sbom_name, options);
 
             let mut header = tar::Header::new_gnu();
             header.set_size(sbom_csv.len() as u64);
             header.set_mode(0o644);
             header.set_cksum();
-            archive.append_data(&mut header, format!("{}_sbom_licenses.csv", &sbom_name), &*sbom_csv)?;
+            archive.append_data(
+                &mut header,
+                format!(
+                    "{}_sbom_licenses.csv",
+                    &get_sanitize_filename(String::from(&self.sbom_license.sbom_name))
+                ),
+                &*sbom_csv,
+            )?;
 
             let mut header = tar::Header::new_gnu();
             header.set_size(license_ref_csv.len() as u64);
@@ -155,7 +164,10 @@ impl LicenseExporter {
             header.set_cksum();
             archive.append_data(
                 &mut header,
-                format!("{}_license_ref.csv", &sbom_name),
+                format!(
+                    "{}_license_ref.csv",
+                    &get_sanitize_filename(String::from(&self.sbom_license.sbom_name))
+                ),
                 &*license_ref_csv,
             )?;
 
@@ -169,6 +181,7 @@ impl LicenseExporter {
 mod tests {
     use crate::license::license_exporter::LicenseExporter;
     use crate::license::license_scanner::LicenseScanner;
+    use crate::utils::get_sanitize_filename;
     use bombastic_model::data::SBOM;
     use std::fs::File;
     use std::io::Write;
@@ -177,6 +190,14 @@ mod tests {
     fn load_sbom_file(path: impl AsRef<Path>) -> Result<SBOM, anyhow::Error> {
         let data = std::fs::read(&path).unwrap_or_else(|e| panic!("read file failed {:?}", e));
         Ok(SBOM::parse(&data).unwrap_or_else(|_| panic!("failed to parse test data: {}", path.as_ref().display())))
+    }
+
+    #[tokio::test]
+    async fn test_get_sanitize_filename() {
+        let sbom_name =
+            "/var/lib/containers/storage/vfs/dir/0efa662cc0258b94827838a8c160142b92fefb10b165b204705d9903b3286e89";
+        let result = get_sanitize_filename(sbom_name.to_string());
+        assert!(!result.contains("/"));
     }
 
     #[tokio::test]

--- a/spog/api/src/utils/mod.rs
+++ b/spog/api/src/utils/mod.rs
@@ -1,1 +1,10 @@
 pub mod spdx;
+
+pub fn get_sanitize_filename(sbom_name: String) -> String {
+    let options = sanitize_filename::Options {
+        truncate: true,
+        windows: true,
+        replacement: "_",
+    };
+    sanitize_filename::sanitize_with_options(sbom_name, options)
+}


### PR DESCRIPTION
@bxf12315 this PR should help us to avoid dealing with special characters in the filenames when for any reason the SBOM Name contains special characters

This is the SBOM file that Pavel from QE shared with us and can be used to validate whether or not the fix works. I tested it with the UI and it worked!

[trustification-product-1-2-1-sbom.json](https://github.com/user-attachments/files/18076866/trustification-product-1-2-1-sbom.json)
